### PR TITLE
feat: adds user-scoped task retrieval by ID with validation

### DIFF
--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -65,6 +65,27 @@ export class TaskService {
     }
   }
 
+  /**
+   * Busca uma task pelo ID, garantindo que ela pertença ao usuário especificado.
+   * 
+   * @param taskId ID da task a ser buscada.
+   * @param userId ID do usuário proprietário da task.
+   * 
+   * @throws HTTPError se a task não for encontrada ou não pertencer ao usuário.
+   * @returns A task encontrada, mapeada para o modelo Task.
+   */
+  public async getTaskById(taskId: string, userId: string): Promise<Task> {
+    const task = await prismaRepository.task.findUnique({
+      where: { id: taskId },
+    });
+
+    if (!task || task.userId !== userId) {
+      throw new HTTPError(404, "Task not found");
+    }
+
+    return this.mapToModel(task);
+  }
+
   private mapToModel(entity: TaskEntity): Task {
     return new Task(
       entity.id,

--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -86,6 +86,25 @@ export class TaskService {
     return this.mapToModel(task);
   }
 
+  /**
+   * Deleta uma task pelo ID, garantindo que ela pertença ao usuário especificado.
+   * 
+   * @param taskId ID da task a ser deletada.
+   * @param userId ID do usuário proprietário da task.
+   * 
+   * @throws HTTPError se a task não for encontrada ou não pertencer ao usuário.
+   * @returns A task deletada, mapeada para o modelo Task.
+   */
+  public async deleteTask(taskId: string, userId: string): Promise<Task> {
+    const taskToBeDeleted = await this.getTaskById(taskId, userId);
+
+    const taskDeleted = await prismaRepository.task.delete({
+      where: { id: taskToBeDeleted.toJSON().id },
+    });
+
+    return this.mapToModel(taskDeleted);
+  }
+
   private mapToModel(entity: TaskEntity): Task {
     return new Task(
       entity.id,


### PR DESCRIPTION
# Descrição
Este PR introduz um método para buscar uma tarefa pelo seu ID, garantindo que ela pertença ao usuário especificado. Melhora a segurança e integridade dos dados ao retornar erro de não encontradas caso a tarefa não exista ou não pertença ao usuário.

## Alterações realizadas:
- Adição de método de busca de tarefa por ID com validação de ownership no serviço de tarefas (`src/services/task.service.ts`)